### PR TITLE
Fix typos in quotes

### DIFF
--- a/data/quotes.yml
+++ b/data/quotes.yml
@@ -49,7 +49,7 @@
   twitter: "brucel"
   url: "http://www.brucelawson.co.uk/"
 -
-  title: "Certaines personnes, lorsqu’ils sont confrontés à un problème, pensent <strong>”J’ai une idée’, je vais utiliser des expressions régulières.“</strong> Maintenant, ils ont deux problèmes."
+  title: "Certaines personnes, lorsqu’elles sont confrontées à un problème, pensent <strong>”J’ai une idée’, je vais utiliser des expressions régulières.“</strong> Maintenant, elles ont deux problèmes."
   author: "Jamie Zawinski"
   twitter: "jwz"
   url: "http://www.jwz.org/"
@@ -114,7 +114,7 @@
   twitter: "cyshini"
   url: ""
 -
-  title: "Le <strong>processus de conception</strong> est bizarre et compliqué, car il <strong>implique des personnes</strong>, qui sont bizarres et compliqués."
+  title: "Le <strong>processus de conception</strong> est bizarre et compliqué, car il <strong>implique des personnes</strong>, qui sont bizarres et compliquées."
   author: "Brad Frost"
   twitter: "brad_frost"
   url: "http://bradfrostweb.com/"
@@ -239,7 +239,7 @@
   twitter: ""
   url: ""
 -
-  title: "Ne pas planifiez pas l’avenir par le passé."
+  title: "Ne pas planifier l’avenir par le passé."
   author: "Kim Dotcom"
   twitter: ""
   url: ""
@@ -259,7 +259,7 @@
   twitter: "stephenhay"
   url: ""
 -
-  title: "La façon dont les Media Queries CSS sont présentées pour règler les problèmes sur les mobiles, donne aux développeurs la fausse promesse d’une solution simple pour la conception adaptative."
+  title: "La façon dont les Media Queries CSS sont présentées pour régler les problèmes sur les mobiles, donne aux développeurs la fausse promesse d’une solution simple pour la conception adaptative."
   author: "Jason Grigsby"
   twitter: "grigs"
   url: ""
@@ -379,7 +379,7 @@
   twitter: "codepo8‎"
   url: ""
 -
-  title: "Peu connaissances est une chose dangereuse."
+  title: "Un savoir médiocre est une chose dangereuse."
   author: "Alexander Pope"
   twitter: ""
   url: "http://fr.wikipedia.org/wiki/Alexander_Pope"
@@ -414,7 +414,7 @@
   twitter: ""
   url: "http://mobile.smashingmagazine.com/2012/10/08/the-semantic-responsive-design-navicon/ "
 -
-  title: "On parle pas à une brouette, on la pousse"
+  title: "On ne parle pas à une brouette, on la pousse"
   author: "La Sagesse Populaire"
   twitter: ""
   url: "http://www.insertafter.com/articles-capskiller_stop_aux_majuscules.html"
@@ -529,7 +529,7 @@
   twitter: ""
   url: "http://www.antichamber-game.com/"
 -
-  title: "Creuser un peu plus et pour trouver quelque chose de nouveau."
+  title: "Creusez un peu plus, vous pourriez trouver quelque chose de nouveau."
   author: "Antichamber"
   twitter: ""
   url: "http://www.antichamber-game.com/"
@@ -544,7 +544,7 @@
   twitter: ""
   url: "http://www.antichamber-game.com/"
 -
-  title: "Les problèmes complexes sont plus faciles quand ils sont résolu une étape à la fois."
+  title: "Les problèmes complexes sont plus faciles lorsqu’ils sont résolus étape par étape."
   author: "Antichamber"
   twitter: ""
   url: "http://www.antichamber-game.com/"


### PR DESCRIPTION
I tried to fix this one but didn't get it:
> "Ne pas planifiez pas l’avenir par le passé."