### PR TITLE
Fix send a PR link in about page

### DIFF
--- a/source/about.html.slim
+++ b/source/about.html.slim
@@ -15,7 +15,7 @@ title: À propos
 
       ## Comment contribuer ?
 
-      Pour partager une citation, [lisez le README](https://github.com/flexbox/webcitation/blob/master/README.md) ou [créez une pull request](https://github.com/flexbox/webcitation/blob/master/data/quotes.json).
+      Pour partager une citation, [lisez le README](https://github.com/flexbox/webcitation/blob/master/README.md) ou [créez une pull request](https://github.com/flexbox/webcitation/blob/master/data/quotes.yml).
 
     h2 À propos de l’application
 


### PR DESCRIPTION
I wished to contribute from the "about" page but the link was broken.